### PR TITLE
Genre management: full CRUD + seeds

### DIFF
--- a/app/controllers/genres_controller.rb
+++ b/app/controllers/genres_controller.rb
@@ -1,0 +1,46 @@
+class GenresController < ApplicationController
+  before_action :set_genre, only: %i[edit update destroy]
+
+  def index
+    @genres = Genre.order(:name)
+  end
+
+  def new
+    @genre = Genre.new
+  end
+
+  def create
+    @genre = Genre.new(genre_params)
+    if @genre.save
+      redirect_to genres_path, notice: "Genre created."
+    else
+      render :new, status: :unprocessable_content
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @genre.update(genre_params)
+      redirect_to genres_path, notice: "Genre updated."
+    else
+      render :edit, status: :unprocessable_content
+    end
+  end
+
+  def destroy
+    @genre.destroy
+    redirect_to genres_path, notice: "Genre removed."
+  end
+
+  private
+
+  def set_genre
+    @genre = Genre.find(params[:id])
+  end
+
+  def genre_params
+    params.require(:genre).permit(:name)
+  end
+end

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,0 +1,3 @@
+class Genre < ApplicationRecord
+  validates :name, presence: true, uniqueness: true
+end

--- a/app/views/genres/_form.html.erb
+++ b/app/views/genres/_form.html.erb
@@ -1,0 +1,21 @@
+<%= form_with model: genre, class: "space-y-4" do |f| %>
+  <% if genre.errors.any? %>
+    <div class="bg-red-50 border border-red-200 rounded p-4 text-red-700">
+      <ul class="list-disc list-inside">
+        <% genre.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= f.label :name, class: "block text-sm font-medium text-gray-700" %>
+    <%= f.text_field :name, class: "mt-1 block w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" %>
+  </div>
+
+  <div class="flex gap-3 pt-2">
+    <%= f.submit class: "bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700 cursor-pointer" %>
+    <%= link_to "Cancel", genres_path, class: "px-4 py-2 text-gray-600 hover:underline" %>
+  </div>
+<% end %>

--- a/app/views/genres/edit.html.erb
+++ b/app/views/genres/edit.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "Edit Genre" %>
+<h1 class="text-2xl font-bold mb-6">Edit Genre</h1>
+<%= render "form", genre: @genre %>

--- a/app/views/genres/index.html.erb
+++ b/app/views/genres/index.html.erb
@@ -1,0 +1,22 @@
+<% content_for :title, "Genres" %>
+
+<div class="flex items-center justify-between mb-6">
+  <h1 class="text-2xl font-bold">Genres</h1>
+  <%= link_to "Add Genre", new_genre_path, class: "bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700" %>
+</div>
+
+<% if @genres.any? %>
+  <ul class="bg-white border border-gray-200 rounded-lg shadow-sm divide-y divide-gray-200">
+    <% @genres.each do |genre| %>
+      <li class="flex items-center justify-between px-4 py-3">
+        <span class="text-gray-900 font-medium"><%= genre.name %></span>
+        <div class="flex gap-4 text-sm">
+          <%= link_to "Edit", edit_genre_path(genre), class: "text-indigo-600 hover:underline" %>
+          <%= button_to "Delete", genre_path(genre), method: :delete, class: "text-red-600 hover:underline bg-transparent border-0 p-0 cursor-pointer", data: { turbo_confirm: "Delete #{genre.name}?" } %>
+        </div>
+      </li>
+    <% end %>
+  </ul>
+<% else %>
+  <p class="text-gray-500">No genres yet. <%= link_to "Add one!", new_genre_path, class: "text-indigo-600 hover:underline" %></p>
+<% end %>

--- a/app/views/genres/new.html.erb
+++ b/app/views/genres/new.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "Add Genre" %>
+<h1 class="text-2xl font-bold mb-6">Add Genre</h1>
+<%= render "form", genre: @genre %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,6 +29,7 @@
         <%= link_to "Board Game Tracker", root_path, class: "text-xl font-bold text-indigo-600" %>
         <div class="flex gap-6">
           <%= link_to "Games", root_path, class: "text-gray-600 hover:text-indigo-600 font-medium" %>
+          <%= link_to "Genres", genres_path, class: "text-gray-600 hover:text-indigo-600 font-medium" %>
         </div>
       </div>
     </nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
   resources :games
+  resources :genres
 
   root "games#index"
 end

--- a/db/migrate/20260402075401_create_genres.rb
+++ b/db/migrate/20260402075401_create_genres.rb
@@ -1,0 +1,10 @@
+class CreateGenres < ActiveRecord::Migration[8.1]
+  def change
+    create_table :genres do |t|
+      t.string :name
+
+      t.timestamps
+    end
+    add_index :genres, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_02_072417) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_02_075401) do
   create_table "games", force: :cascade do |t|
     t.string "bgg_url"
     t.integer "complexity"
@@ -25,5 +25,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_02_072417) do
     t.string "name"
     t.integer "times_played", default: 0, null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "genres", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "name"
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_genres_on_name", unique: true
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,7 @@
 # This file should ensure the existence of records required to run the application in every environment (production,
 # development, test). The code here should be idempotent so that it can be executed at any point in every environment.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+
+%w[Strategy Party Cooperative Deck-building Worker\ Placement Trivia Family Abstract Thematic Wargame].each do |name|
+  Genre.find_or_create_by!(name: name)
+end

--- a/spec/requests/genres_spec.rb
+++ b/spec/requests/genres_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+RSpec.describe "Genres", type: :request do
+  describe "POST /genres" do
+    it "creates a genre and redirects when name is valid" do
+      expect {
+        post "/genres", params: { genre: { name: "Strategy" } }
+      }.to change(Genre, :count).by(1)
+
+      expect(response).to redirect_to(genres_path)
+    end
+
+    it "does not create a genre when name is blank" do
+      expect {
+        post "/genres", params: { genre: { name: "" } }
+      }.not_to change(Genre, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    it "does not create a genre when name is a duplicate" do
+      Genre.create!(name: "Strategy")
+
+      expect {
+        post "/genres", params: { genre: { name: "Strategy" } }
+      }.not_to change(Genre, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+  end
+
+  describe "GET /genres/:id/edit" do
+    it "returns 200" do
+      genre = Genre.create!(name: "Party")
+      get "/genres/#{genre.id}/edit"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "PATCH /genres/:id" do
+    it "updates the genre name and redirects" do
+      genre = Genre.create!(name: "Party")
+      patch "/genres/#{genre.id}", params: { genre: { name: "Party Games" } }
+      expect(genre.reload.name).to eq("Party Games")
+      expect(response).to redirect_to(genres_path)
+    end
+  end
+
+  describe "DELETE /genres/:id" do
+    it "removes the genre and redirects" do
+      genre = Genre.create!(name: "Trivia")
+      expect {
+        delete "/genres/#{genre.id}"
+      }.to change(Genre, :count).by(-1)
+      expect(response).to redirect_to(genres_path)
+    end
+  end
+
+  describe "GET /genres" do
+    it "returns 200" do
+      get "/genres"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "lists genres by name" do
+      Genre.create!(name: "Wargame")
+      Genre.create!(name: "Abstract")
+
+      get "/genres"
+
+      expect(response.body).to match(/Abstract.*Wargame/m)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Migration: genres table with unique name index
- Genre model: presence and uniqueness validations
- GenresController: full CRUD, genres sorted alphabetically
- Views: index list with edit/delete actions, shared new/edit form partial, all styled with Tailwind
- Seeds: 10 default genres (Strategy, Party, Cooperative, Deck-building, Worker Placement, Trivia, Family, Abstract, Thematic, Wargame) loaded idempotently via `find_or_create_by!`
- Genres nav link added to application layout
- 8 request specs covering all CRUD actions and validation behaviour (blank name, duplicate name)

Closes #5

## Test plan
- [ ] `bundle exec rspec spec/requests/genres_spec.rb` — 8 examples, 0 failures
- [ ] `bundle exec rspec` — full suite (21 examples) green
- [ ] `bin/rails db:seed` populates 10 default genres idempotently

🤖 Generated with [Claude Code](https://claude.ai/claude-code)