### PR TITLE
Move genre query ownership from form view to controller

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,5 +1,6 @@
 class GamesController < ApplicationController
   before_action :set_game, only: %i[edit update destroy]
+  before_action :set_genres, only: %i[new create edit update]
 
   def index
     @filter_params = params.permit(:sort, :direction, :condition, :genre_mode, :player_count, :max_playtime, :complexity, :enjoyment, genre_ids: []).to_h.symbolize_keys
@@ -40,6 +41,10 @@ class GamesController < ApplicationController
 
   def set_game
     @game = Game.find(params[:id])
+  end
+
+  def set_genres
+    @genres = Genre.alphabetical_name
   end
 
   def game_params

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -3,4 +3,6 @@ class Genre < ApplicationRecord
   has_many :games, through: :game_genres
 
   validates :name, presence: true, uniqueness: true
+
+  scope :alphabetical_name, -> { order(:name) }
 end

--- a/app/views/games/_form.html.erb
+++ b/app/views/games/_form.html.erb
@@ -55,7 +55,7 @@
   <div>
     <%= f.label :genre_ids, "Genres", class: "block text-sm font-medium text-gray-700" %>
     <div class="mt-1 grid grid-cols-2 gap-2 sm:grid-cols-3">
-      <% Genre.order(:name).each do |genre| %>
+      <% @genres.each do |genre| %>
         <label class="flex items-center gap-2 text-sm text-gray-700">
           <%= check_box_tag "game[genre_ids][]", genre.id, game.genres.include?(genre), id: "game_genre_#{genre.id}" %>
           <%= genre.name %>


### PR DESCRIPTION
## Summary

- Adds `Genre.alphabetical_name` scope — names the ordering contract explicitly
- Adds `before_action :set_genres` to `GamesController` (fires on new/create/edit/update)
- Form now iterates `@genres` instead of calling `Genre.order(:name)` directly

The controller now owns what genres appear in the form. The hidden DB dependency in the view is gone, making the system easier to reason about and test.

## Test plan

- [x] 59 specs pass (no regressions)
- [x] New/edit game forms still render genre checkboxes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
