### PR TITLE
Add expansion via form + visible in index

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,9 +1,10 @@
 class GamesController < ApplicationController
   before_action :set_game, only: %i[edit update destroy]
   before_action :set_genres, only: %i[new create edit update]
+  before_action :set_base_games, only: %i[new create edit update]
 
   def index
-    @filter_params = params.permit(:sort, :direction, :condition, :genre_mode, :player_count, :max_playtime, :complexity, :enjoyment, genre_ids: []).to_h.symbolize_keys
+    @filter_params = params.permit(:sort, :direction, :condition, :genre_mode, :player_count, :max_playtime, :complexity, :enjoyment, :game_type, genre_ids: []).to_h.symbolize_keys
     @games = GameFilter.new(@filter_params).results
     @genres = Genre.order(:name)
   end
@@ -47,11 +48,15 @@ class GamesController < ApplicationController
     @genres = Genre.alphabetical_name
   end
 
+  def set_base_games
+    @base_games = Game.base_games.order(:name)
+  end
+
   def game_params
     params.require(:game).permit(
       :name, :min_players, :max_players, :description,
       :times_played, :bgg_url, :condition, :complexity,
-      :min_playtime, :max_playtime, :enjoyment, genre_ids: []
+      :min_playtime, :max_playtime, :enjoyment, :base_game_id, genre_ids: []
     )
   end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,10 +1,15 @@
 class Game < ApplicationRecord
   has_many :game_genres, dependent: :destroy
   has_many :genres, through: :game_genres
+  belongs_to :base_game, class_name: "Game", optional: true
+  has_many :expansions, class_name: "Game", foreign_key: :base_game_id, dependent: :nullify, inverse_of: :base_game
 
   enum :condition, { mint: 0, good: 1, fair: 2, poor: 3, damaged: 4 }
 
   validates :name, presence: true
   validates :complexity, numericality: { only_integer: true, in: 1..5 }, allow_nil: true
   validates :enjoyment, numericality: { only_integer: true, in: 1..5 }, allow_nil: true
+
+  scope :base_games, -> { where(base_game_id: nil) }
+  scope :expansions_only, -> { where.not(base_game_id: nil) }
 end

--- a/app/views/games/_form.html.erb
+++ b/app/views/games/_form.html.erb
@@ -17,6 +17,15 @@
     <%= text_field_tag "game[name]", game.name, form: "game_form", class: "mt-1 block w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" %>
   </div>
 
+  <div>
+    <%= label_tag :base_game_id, "Base game", class: "block text-sm font-medium text-gray-700" %>
+    <%= select_tag "game[base_game_id]",
+          options_from_collection_for_select(@base_games, :id, :name, game.base_game_id),
+          include_blank: "— none (this is a base game) —",
+          form: "game_form",
+          class: "mt-1 block w-full border border-gray-300 rounded px-3 py-2" %>
+  </div>
+
   <div class="grid grid-cols-2 gap-4">
     <div>
       <%= label_tag :min_players, "Min Players", class: "block text-sm font-medium text-gray-700" %>

--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -110,11 +110,11 @@
         </thead>
         <tbody class="divide-y divide-gray-200">
           <% @games.each do |game| %>
-            <tr class="hover:bg-gray-50">
+            <tr class="hover:bg-gray-50 align-middle">
               <td class="px-4 py-3 font-medium text-gray-900">
                 <%= game.name %>
                 <% if game.base_game %>
-                  <div class="text-xs text-gray-400 font-normal">Expansion of <%= game.base_game.name %></div>
+                  <span style="font-size:10px" class="block mt-1 font-normal text-indigo-500 bg-indigo-50 rounded px-1.5 py-0.5">(expansion of <%= game.base_game.name %>)</span>
                 <% end %>
               </td>
               <td class="px-4 py-3 text-gray-600"><%= game.complexity %></td>
@@ -129,9 +129,11 @@
                   <%= link_to "BGG", game.bgg_url, target: "_blank", rel: "noopener", class: "text-indigo-600 hover:underline" %>
                 <% end %>
               </td>
-              <td class="px-4 py-3 flex gap-3 text-sm">
-                <%= link_to "Edit", edit_game_path(game), class: "text-indigo-600 hover:underline" %>
-                <%= button_to "Delete", game_path(game), method: :delete, class: "text-red-600 hover:underline bg-transparent border-0 p-0 cursor-pointer", data: { turbo_confirm: "Delete #{game.name}?" } %>
+              <td class="px-4 py-3 text-sm align-middle">
+                <div class="flex gap-3">
+                  <%= link_to "Edit", edit_game_path(game), class: "text-indigo-600 hover:underline" %>
+                  <%= button_to "Delete", game_path(game), method: :delete, class: "text-red-600 hover:underline bg-transparent border-0 p-0 cursor-pointer", data: { turbo_confirm: "Delete #{game.name}?" } %>
+                </div>
               </td>
             </tr>
           <% end %>

--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -111,7 +111,12 @@
         <tbody class="divide-y divide-gray-200">
           <% @games.each do |game| %>
             <tr class="hover:bg-gray-50">
-              <td class="px-4 py-3 font-medium text-gray-900"><%= game.name %></td>
+              <td class="px-4 py-3 font-medium text-gray-900">
+                <%= game.name %>
+                <% if game.base_game %>
+                  <div class="text-xs text-gray-400 font-normal">Expansion of <%= game.base_game.name %></div>
+                <% end %>
+              </td>
               <td class="px-4 py-3 text-gray-600"><%= game.complexity %></td>
               <td class="px-4 py-3 text-gray-600"><%= game.enjoyment %></td>
               <td class="px-4 py-3 text-gray-600"><%= game.times_played %></td>

--- a/db/migrate/20260428055440_add_base_game_id_to_games.rb
+++ b/db/migrate/20260428055440_add_base_game_id_to_games.rb
@@ -1,0 +1,6 @@
+class AddBaseGameIdToGames < ActiveRecord::Migration[8.1]
+  def change
+    add_column :games, :base_game_id, :integer
+    add_foreign_key :games, :games, column: :base_game_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_02_080607) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_28_055440) do
   create_table "game_genres", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "game_id", null: false
@@ -21,6 +21,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_02_080607) do
   end
 
   create_table "games", force: :cascade do |t|
+    t.integer "base_game_id"
     t.string "bgg_url"
     t.integer "complexity"
     t.integer "condition"
@@ -45,4 +46,5 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_02_080607) do
 
   add_foreign_key "game_genres", "games"
   add_foreign_key "game_genres", "genres"
+  add_foreign_key "games", "games", column: "base_game_id"
 end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe Game, type: :model do
+  describe ".base_games" do
+    it "returns only games with no base_game_id" do
+      base = create(:game, name: "Catan")
+      create(:game, name: "Catan: Seafarers", base_game_id: base.id)
+
+      expect(Game.base_games).to contain_exactly(base)
+    end
+  end
+
+  describe ".expansions_only" do
+    it "returns only games with a base_game_id" do
+      base = create(:game, name: "Catan")
+      expansion = create(:game, name: "Catan: Seafarers", base_game_id: base.id)
+
+      expect(Game.expansions_only).to contain_exactly(expansion)
+    end
+  end
+
+  describe "deleting a base game" do
+    it "nullifies base_game_id on expansions rather than deleting them" do
+      base = create(:game, name: "Catan")
+      expansion = create(:game, name: "Catan: Seafarers", base_game_id: base.id)
+
+      base.destroy
+
+      expect { expansion.reload }.not_to raise_error
+      expect(expansion.reload.base_game_id).to be_nil
+    end
+  end
+end

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -10,6 +10,17 @@ RSpec.describe "Games", type: :request do
       expect(response).to redirect_to(games_path)
     end
 
+    it "creates an expansion associated to a base game" do
+      base = create(:game, name: "Catan")
+
+      expect {
+        post "/games", params: { game: { name: "Catan: Seafarers", base_game_id: base.id } }
+      }.to change(Game, :count).by(1)
+
+      expansion = Game.find_by(name: "Catan: Seafarers")
+      expect(expansion.base_game).to eq(base)
+    end
+
     it "does not create a game when name is missing" do
       expect {
         post "/games", params: { game: { name: "" } }
@@ -38,6 +49,17 @@ RSpec.describe "Games", type: :request do
 
       expect(response.body).to include('name="genre[name]"')
       expect(response.body).to include('name="context"')
+    end
+
+    it "renders a Base game dropdown listing only base games" do
+      base = create(:game, name: "Catan")
+      expansion = create(:game, name: "Catan: Seafarers", base_game_id: base.id)
+
+      get "/games/new"
+
+      expect(response.body).to include('name="game[base_game_id]"')
+      expect(response.body).to include("Catan")
+      expect(response.body).not_to include("Catan: Seafarers")
     end
 
     it "renders a delete button next to each genre in the game form" do
@@ -270,6 +292,15 @@ RSpec.describe "Games", type: :request do
 
       expect(response.body).to include("Alpha")
       expect(response.body).to include("Beta")
+    end
+
+    it "shows an expansion indicator on expansion rows" do
+      base = create(:game, name: "Catan")
+      create(:game, name: "Catan: Seafarers", base_game_id: base.id)
+
+      get "/games", params: { game_type: "all" }
+
+      expect(response.body).to include("Expansion of Catan")
     end
 
     it "renders the add-genre form in the filter panel" do


### PR DESCRIPTION
## Parent PRD

#34

## What to build

Add end-to-end support for creating and viewing expansions. This slice covers everything needed to record an expansion in the database and see it in the index:

- Migrate `base_game_id` nullable FK onto `games`
- Wire up `belongs_to :base_game` (optional) and `has_many :expansions` (dependent: :nullify) on the Game model, with `base_games` and `expansions_only` scopes
- Add a "Base game" dropdown to the new/edit game form, listing only base games (blank = this is a base game)
- Permit `base_game_id` in the controller; assign `@base_games` for the dropdown
- Display an "Expansion of [Base Game Name]" indicator on expansion rows in the index
- No game_type filtering yet — expansions appear alongside base games in the flat list

## Acceptance criteria

- [ ] `games` table has a nullable `base_game_id` FK referencing `games.id`
- [ ] `Game.base_games` returns only games with no `base_game_id`
- [ ] `Game.expansions_only` returns only games with a `base_game_id`
- [ ] The new/edit form renders a "Base game" dropdown populated with base games only
- [ ] Submitting the form with a `base_game_id` saves the expansion association
- [ ] Submitting with a blank `base_game_id` saves the game as a base game
- [ ] Index rows for expansions display "Expansion of [Base Game Name]"
- [ ] Deleting a base game nullifies `base_game_id` on its expansions rather than deleting them
- [ ] Model scopes and form/index behaviour covered by unit and request specs

## Blocked by

None — can start immediately.

## User stories addressed

- User story 1
- User story 4
- User story 5
- User story 6
- User story 8
- User story 10
